### PR TITLE
Update GitHub notifications

### DIFF
--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -25,13 +25,18 @@ jobs:
         with:
           name: yarn-audit-report-boomerang-opentelemetry-plugin
           path: yarn-report.json
-      - name: Send Notification
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: "*Boomerang-OTel-Plugin Yarn-Audit Report*: ${{ steps.audit.outcome }}\nPlease check the report here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Since GitHub cannot send emails directly, we use an external API
+      - name: Send Notification via Resend
+        run: |
+          curl -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer ${{ secrets.RESEND_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
+              "to": ["info.inspectit@novatec-gmbh.de"],
+              "subject": "Boomerang-OTel-PluginDependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "html": "<p>The Dependency-Check for ${{ github.repository }} completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
+            }'
       # if yarn audit failed, the job should also fail, but only after the results were uploaded
       - name: Validate yarn audit outcome
         if: ${{ steps.audit.outcome == 'failure' }}

--- a/.github/workflows/security_check.yml
+++ b/.github/workflows/security_check.yml
@@ -34,7 +34,7 @@ jobs:
             -d '{
               "from": "inspectIT Ocelot DepCheck <inspectit-ocelot-depcheck@resend.dev>",
               "to": ["info.inspectit@novatec-gmbh.de"],
-              "subject": "Boomerang-OTel-PluginDependency-Check Report - ${{ steps.depcheck.outcome }}",
+              "subject": "Boomerang-OTel-Plugin Dependency-Check Report - ${{ steps.depcheck.outcome }}",
               "html": "<p>The Dependency-Check for ${{ github.repository }} completed with status: <strong>${{ steps.depcheck.outcome }}</strong></p><p>Please check the report here: <a href='https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'>View Report</a></p>"
             }'
       # if yarn audit failed, the job should also fail, but only after the results were uploaded


### PR DESCRIPTION
Replace Slack notifications with Email. Since GitHub cannot send emails directy, we use [Resend](https://resend.com/).